### PR TITLE
Add a pub with a vcard author

### DIFF
--- a/openvivo/README.md
+++ b/openvivo/README.md
@@ -4,7 +4,7 @@
 
 The data here is a snapshot of the OpenVIVO data.
 
-OpenVIVO contains self-asserted information from researchers around the world.  All informationw in OpenVIVO is identified with persistent identifiers:
+OpenVIVO contains self-asserted information from researchers around the world.  All information in OpenVIVO is identified with persistent identifiers:
 
 * ORCiD for people
 * ISSN for Journals

--- a/sample-data.n3
+++ b/sample-data.n3
@@ -91,8 +91,15 @@
         vivo:relatedBy            <http://vivo.mydomain.edu/individual/n7123> , <http://vivo.mydomain.edu/individual/n2808> , <http://vivo.mydomain.edu/individual/n10598> .
 
 <http://vivo.mydomain.edu/individual/n7578>
-        bibo:volume         "15" ;
-        vivo:dateTimeValue  <http://vivo.mydomain.edu/individual/n869> .
+        a                   bibo:AcademicArticle ;
+        rdfs:label          "Metabolic functions of C. Elegans"@en-US ;
+        bibo:issue          "45" ;
+        bibo:pageEnd        "678" ;
+        bibo:pageStart      "671" ;
+        bibo:volume         "111" ;
+        vivo:dateTimeValue  <http://vivo.mydomain.edu/individual/n869> ;
+        vivo:hasPublicationVenue  <http://vivo.mydomain.edu/individual/n6749> ;
+        vivo:relatedBy            <http://vivo.mydomain.edu/individual/n7124> , <http://vivo.mydomain.edu/individual/n2809> .
 
 <http://vivo.mydomain.edu/individual/n4860>
         vivo:dateTimeValue  <http://vivo.mydomain.edu/individual/n190> ;
@@ -250,7 +257,26 @@
 <http://vivo.mydomain.edu/individual/n8066>
         a             vivo:Authorship ;
         vivo:relates  <http://vivo.mydomain.edu/individual/n3728> , <http://vivo.mydomain.edu/individual/n128> .
-
+        
+<http://vivo.mydomain.edu/individual/n7124>
+        a             vivo:Authorship ;
+        vivo:rank     "1"^^xsd:int ;
+        vivo:relates  <http://vivo.mydomain.edu/individual/n7578> , <http://vivo.mydomain.edu/individual/n6870> .
+        
+<http://vivo.mydomain.edu/individual/n2809>
+        a             vivo:Authorship ;
+        vivo:rank     "2"^^xsd:int ;
+        vivo:relates  <http://vivo.mydomain.edu/individual/n7578> , <http://vivo.mydomain.edu/individual/n1111> .
+        
+<http://vivo.mydomain.edu/individual/n1111>
+		a             vcard:Individual ;
+		vcard:hasName <http://vivo.mydomain.edu/individual/n1112> .
+		
+<http://vivo.mydomain.edu/individual/n1112>
+		a			  vcard:Name ;
+		vcard:familyName "Veronique"@en ;
+    	vcard:givenName "Al"@en .
+		
 <http://vivo.mydomain.edu/individual/n269>
         a                      vivo:TeacherRole ;
         rdfs:label             "Instructor"@en-US ;
@@ -916,6 +942,10 @@
         rdfs:label                "Journal of Political Rhetoric"@en-US ;
         vivo:contributingRole     <http://vivo.mydomain.edu/individual/n722> , <http://vivo.mydomain.edu/individual/n5685> ;
         vivo:publicationVenueFor  <http://vivo.mydomain.edu/individual/n3954> .
+        
+<http://vivo.mydomain.edu/individual/n6749>
+        a                         bibo:Journal ;
+        rdfs:label                "Journal of Analytic Chemistry"@en-US .
 
 <http://vivo.mydomain.edu/individual/n1271>
         a                      bibo:Journal ;


### PR DESCRIPTION
Addresses https://jira.duraspace.org/browse/VIVO-1604

# What this does
Adds a new publication to the sample data, with a new journal, and two authors.  One of the authors is an existing person in the sample data.  The other is a "vcard author" -- the authorship points to a vcard which as a name entity with name parts.

#How to test
Load sample data.  VIsit Peter Jaspers in the Chemistry department.  See he has a paper regarding C. elegans.  Visit that paper.  See the paper has two authors.  One is Peter Jaspers, the other is a vcard author.  The name of the vcard author appears as Veronique, Al without a link to the author, since the authors is a vcard.  The number of persons in VIVO does not include the vcard author.

